### PR TITLE
Add loss calculation to GPT2Model for language modeling

### DIFF
--- a/q/gpt2.py
+++ b/q/gpt2.py
@@ -28,7 +28,7 @@ class GPT2Output:
     # used to update the model's parameters through backpropagation. The loss
     # is typically computed using a loss function, such as cross-entropy loss,
     #
-    # Tensor shape: (1, )
+    # Tensor shape: ()
     loss: mx.array | None = None
 
 

--- a/q/gpt2.py
+++ b/q/gpt2.py
@@ -7,11 +7,16 @@ from .common import GPT2HyperParams, GPT2Params
 
 @dataclass
 class GPT2Output:
-    # Prediction scores of the language modeling head (scores for each vocabulary token before
-    # SoftMax).
+    # Prediction scores of the language modeling head (scores for each
+    # vocabulary token before SoftMax).
+    #
+    # In language models, "logits" refer to the raw scores obtained from the
+    # model's output layer. These scores correspond to each class or token and
+    # are not yet in a form that can be interpreted as probabilities. Typically,
+    # applying the softmax function to these logits yields the probabilities of
+    # each class or token being.
     #
     # Tensor shape: (batch_size, sequence_length, config.vocab_size)
-    # where batch_size is always 1
     logits: mx.array
 
 

--- a/q/params.py
+++ b/q/params.py
@@ -3,8 +3,10 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, Union
+
 import mlx.core as mx
-from mlx.core import load as load_safetensors_mlx, save_safetensors
+from mlx.core import load as load_safetensors_mlx
+from mlx.core import save_safetensors
 
 from .common import MODEL_SIZE, GPT2HyperParams, GPT2Params, ModelSize
 

--- a/test/test_gpt2.py
+++ b/test/test_gpt2.py
@@ -1,5 +1,7 @@
 import mlx.core as mx
-from q.gpt2 import GPT2HyperParams, GPT2Model, GPT2Params
+import mlx.nn as nn
+
+from q.gpt2 import GPT2HyperParams, GPT2Model, GPT2Output, GPT2Params
 
 
 def test_logits_shape():
@@ -79,3 +81,98 @@ def test_logits_shape():
     assert logits.shape == (1, len(inputs), hparams["n_vocab"])
 
     print("Logits shape test passed!")
+
+
+def test_compute_loss():
+    # Define dummy hyperparameters
+    hparams = GPT2HyperParams(
+        n_layer=1,
+        n_head=1,
+        n_embd=16,
+        n_vocab=32,
+        rotary_ndims=8,
+    )
+
+    # Define dummy parameters
+    wte = mx.random.uniform(shape=(hparams["n_vocab"], hparams["n_embd"]))
+    wpe = mx.random.uniform(shape=(hparams["n_vocab"], hparams["n_embd"]))
+    params = GPT2Params(
+        wte=wte,
+        wpe=wpe,
+        blocks=[
+            {
+                "ln_1": {
+                    "g": mx.ones(hparams["n_embd"]),
+                    "b": mx.zeros(hparams["n_embd"]),
+                },
+                "attn": {
+                    "c_attn": {
+                        "w": mx.random.uniform(
+                            shape=(hparams["n_embd"], 3 * hparams["n_embd"])
+                        ),
+                        "b": mx.zeros(3 * hparams["n_embd"]),
+                    },
+                    "c_proj": {
+                        "w": mx.random.uniform(
+                            shape=(hparams["n_embd"], hparams["n_embd"])
+                        ),
+                        "b": mx.zeros(hparams["n_embd"]),
+                    },
+                },
+                "ln_2": {
+                    "g": mx.ones(hparams["n_embd"]),
+                    "b": mx.zeros(hparams["n_embd"]),
+                },
+                "mlp": {
+                    "c_fc": {
+                        "w": mx.random.uniform(
+                            shape=(hparams["n_embd"], 4 * hparams["n_embd"])
+                        ),
+                        "b": mx.zeros(4 * hparams["n_embd"]),
+                    },
+                    "c_proj": {
+                        "w": mx.random.uniform(
+                            shape=(4 * hparams["n_embd"], hparams["n_embd"])
+                        ),
+                        "b": mx.zeros(hparams["n_embd"]),
+                    },
+                },
+            }
+            for _ in range(hparams["n_layer"])
+        ],
+        ln_f={
+            "g": mx.ones(hparams["n_embd"]),
+            "b": mx.zeros(hparams["n_embd"]),
+        },
+    )
+
+    # Create GPT2Model instance
+    model = GPT2Model(params, hparams)
+
+    # Define dummy input
+    inputs = [1, 2, 3]
+
+    # Case 1: Test without compute_loss (default behavior)
+    output_without_loss = model(inputs)
+    assert isinstance(output_without_loss, GPT2Output)
+    assert output_without_loss.logits.shape == (1, len(inputs), hparams["n_vocab"])
+    assert output_without_loss.loss is None
+
+    # Case 2: Test with compute_loss=True
+    output_with_loss = model(inputs, compute_loss=True)
+    assert isinstance(output_with_loss, GPT2Output)
+    assert output_with_loss.logits.shape == (1, len(inputs), hparams["n_vocab"])
+    assert output_with_loss.loss is not None
+    assert output_with_loss.loss.shape == ()  # Scalar loss
+
+    # Verify loss is computed correctly by manually calculating it
+    # Targets are inputs shifted right by one position
+    targets = mx.array(inputs[1:])  # No padding token needed
+    logits_for_loss = output_with_loss.logits[0, :-1, :]
+    logits_2d = mx.reshape(logits_for_loss, (-1, logits_for_loss.shape[-1]))
+    expected_loss = mx.mean(nn.losses.cross_entropy(logits_2d, targets))
+
+    # Check that our computed loss matches the expected loss
+    assert mx.allclose(output_with_loss.loss, expected_loss)
+
+    print("Compute loss test passed!")

--- a/test/test_gpt2.py
+++ b/test/test_gpt2.py
@@ -1,10 +1,9 @@
 import os
 
 import mlx.core as mx
-import mlx.nn as nn
 import pytest
 
-from q.gpt2 import GPT2Model, GPT2Output
+from q.gpt2 import GPT2Model
 from q.params import load_hparams_and_params
 
 models_dir = os.path.join(os.path.dirname(__file__), "..", "models")

--- a/test/test_gpt2.py
+++ b/test/test_gpt2.py
@@ -1,81 +1,37 @@
+import os
+
 import mlx.core as mx
 import mlx.nn as nn
+import pytest
 
-from q.gpt2 import GPT2HyperParams, GPT2Model, GPT2Output, GPT2Params
+from q.gpt2 import GPT2Model, GPT2Output
+from q.params import load_hparams_and_params
+
+models_dir = os.path.join(os.path.dirname(__file__), "..", "models")
 
 
-def test_logits_shape():
-    # Define dummy hyperparameters
-    hparams = GPT2HyperParams(
-        n_layer=1,
-        n_head=1,
-        n_embd=16,
-        n_vocab=32,
-        rotary_ndims=8,
-    )
+@pytest.fixture
+def gpt2_hparams_and_params():
+    """Fixture that loads hparams and params for the specified model size."""
+    return load_hparams_and_params(model_size="124M", models_dir=models_dir)
 
-    # Define dummy parameters
-    wte = mx.random.uniform(shape=(hparams["n_vocab"], hparams["n_embd"]))
-    wpe = mx.random.uniform(shape=(hparams["n_vocab"], hparams["n_embd"]))
 
-    params = GPT2Params(
-        wte=wte,
-        wpe=wpe,
-        blocks=[
-            {
-                "ln_1": {
-                    "g": mx.ones(hparams["n_embd"]),
-                    "b": mx.zeros(hparams["n_embd"]),
-                },
-                "attn": {
-                    "c_attn": {
-                        "w": mx.random.uniform(
-                            shape=(hparams["n_embd"], 3 * hparams["n_embd"])
-                        ),
-                        "b": mx.zeros(3 * hparams["n_embd"]),
-                    },
-                    "c_proj": {
-                        "w": mx.random.uniform(
-                            shape=(hparams["n_embd"], hparams["n_embd"])
-                        ),
-                        "b": mx.zeros(hparams["n_embd"]),
-                    },
-                },
-                "ln_2": {
-                    "g": mx.ones(hparams["n_embd"]),
-                    "b": mx.zeros(hparams["n_embd"]),
-                },
-                "mlp": {
-                    "c_fc": {
-                        "w": mx.random.uniform(
-                            shape=(hparams["n_embd"], 4 * hparams["n_embd"])
-                        ),
-                        "b": mx.zeros(4 * hparams["n_embd"]),
-                    },
-                    "c_proj": {
-                        "w": mx.random.uniform(
-                            shape=(4 * hparams["n_embd"], hparams["n_embd"])
-                        ),
-                        "b": mx.zeros(hparams["n_embd"]),
-                    },
-                },
-            }
-            for _ in range(hparams["n_layer"])
-        ],
-        ln_f={
-            "g": mx.ones(hparams["n_embd"]),
-            "b": mx.zeros(hparams["n_embd"]),
-        },
-    )
+@pytest.fixture
+def gpt2_model(gpt2_hparams_and_params):
+    """Fixture that creates a GPT2Model instance with the loaded parameters."""
+    hparams, params = gpt2_hparams_and_params
+    return GPT2Model(params, hparams)
 
-    # Create GPT2Model instance
-    model = GPT2Model(params, hparams)
 
-    # Define dummy input
+def test_logits_shape(gpt2_model, gpt2_hparams_and_params):
+    # Unpack the hparams and params
+    hparams, _ = gpt2_hparams_and_params
+
+    # Define test input
     inputs = [1, 2, 3]
 
     # Get logits
-    logits = model(inputs).logits
+    logits = gpt2_model(inputs).logits
 
     # Assert the shape of logits
     assert logits.shape == (1, len(inputs), hparams["n_vocab"])
@@ -83,96 +39,23 @@ def test_logits_shape():
     print("Logits shape test passed!")
 
 
-def test_compute_loss():
-    # Define dummy hyperparameters
-    hparams = GPT2HyperParams(
-        n_layer=1,
-        n_head=1,
-        n_embd=16,
-        n_vocab=32,
-        rotary_ndims=8,
-    )
+def test_compute_loss(gpt2_model, gpt2_hparams_and_params):
+    # Unpack the hparams
+    hparams, _ = gpt2_hparams_and_params
 
-    # Define dummy parameters
-    wte = mx.random.uniform(shape=(hparams["n_vocab"], hparams["n_embd"]))
-    wpe = mx.random.uniform(shape=(hparams["n_vocab"], hparams["n_embd"]))
-    params = GPT2Params(
-        wte=wte,
-        wpe=wpe,
-        blocks=[
-            {
-                "ln_1": {
-                    "g": mx.ones(hparams["n_embd"]),
-                    "b": mx.zeros(hparams["n_embd"]),
-                },
-                "attn": {
-                    "c_attn": {
-                        "w": mx.random.uniform(
-                            shape=(hparams["n_embd"], 3 * hparams["n_embd"])
-                        ),
-                        "b": mx.zeros(3 * hparams["n_embd"]),
-                    },
-                    "c_proj": {
-                        "w": mx.random.uniform(
-                            shape=(hparams["n_embd"], hparams["n_embd"])
-                        ),
-                        "b": mx.zeros(hparams["n_embd"]),
-                    },
-                },
-                "ln_2": {
-                    "g": mx.ones(hparams["n_embd"]),
-                    "b": mx.zeros(hparams["n_embd"]),
-                },
-                "mlp": {
-                    "c_fc": {
-                        "w": mx.random.uniform(
-                            shape=(hparams["n_embd"], 4 * hparams["n_embd"])
-                        ),
-                        "b": mx.zeros(4 * hparams["n_embd"]),
-                    },
-                    "c_proj": {
-                        "w": mx.random.uniform(
-                            shape=(4 * hparams["n_embd"], hparams["n_embd"])
-                        ),
-                        "b": mx.zeros(hparams["n_embd"]),
-                    },
-                },
-            }
-            for _ in range(hparams["n_layer"])
-        ],
-        ln_f={
-            "g": mx.ones(hparams["n_embd"]),
-            "b": mx.zeros(hparams["n_embd"]),
-        },
-    )
-
-    # Create GPT2Model instance
-    model = GPT2Model(params, hparams)
-
-    # Define dummy input
-    inputs = [1, 2, 3]
+    # Define test input
+    inputs = [15496, 2159]
 
     # Case 1: Test without compute_loss (default behavior)
-    output_without_loss = model(inputs)
-    assert isinstance(output_without_loss, GPT2Output)
-    assert output_without_loss.logits.shape == (1, len(inputs), hparams["n_vocab"])
+    output_without_loss = gpt2_model(inputs)
     assert output_without_loss.loss is None
 
     # Case 2: Test with compute_loss=True
-    output_with_loss = model(inputs, compute_loss=True)
-    assert isinstance(output_with_loss, GPT2Output)
-    assert output_with_loss.logits.shape == (1, len(inputs), hparams["n_vocab"])
+    output_with_loss = gpt2_model(inputs, compute_loss=True)
     assert output_with_loss.loss is not None
     assert output_with_loss.loss.shape == ()  # Scalar loss
 
-    # Verify loss is computed correctly by manually calculating it
-    # Targets are inputs shifted right by one position
-    targets = mx.array(inputs[1:])  # No padding token needed
-    logits_for_loss = output_with_loss.logits[0, :-1, :]
-    logits_2d = mx.reshape(logits_for_loss, (-1, logits_for_loss.shape[-1]))
-    expected_loss = mx.mean(nn.losses.cross_entropy(logits_2d, targets))
+    expected_loss = mx.array(8.682313919067383)
 
     # Check that our computed loss matches the expected loss
     assert mx.allclose(output_with_loss.loss, expected_loss)
-
-    print("Compute loss test passed!")

--- a/test/test_params.py
+++ b/test/test_params.py
@@ -1,11 +1,13 @@
-from typing import Any, Dict
 import os
 import tempfile
+from typing import Any, Dict
+
 import mlx.core as mx
 import pytest
 from safetensors.numpy import load_file
-from q.params import build_params_from_safetensors, save_params_to_safetensors
+
 from q.common import GPT2Params
+from q.params import build_params_from_safetensors, save_params_to_safetensors
 
 
 def test_build_params_from_safetensors() -> None:


### PR DESCRIPTION
closes https://github.com/ishikawa/q/issues/23

This PR introduces loss calculation functionality to the GPT2Model class, enabling the computation of language modeling loss for next-token prediction.

Key changes:
- Update `GPT2Output` dataclass to include an optional `loss` field
- Modify `GPT2Model.__call__` method to support loss computation
- Add `compute_loss` parameter to `GPT2Model.__call__` method
- Implement loss calculation using sparse categorical cross-entropy

The loss calculation is performed when `compute_loss` is set to `True` and there are at least two input tokens. The implementation uses the `mlx.nn.losses.cross_entropy` function to compute the loss between the predicted logits and the target tokens.

Example usage of the new loss calculation:

```python
model = GPT2Model(params, hparams)
inputs = [1, 2, 3, 4, 5]  # Example input token sequence
output = model(inputs, compute_loss=True)
print(output.loss)  # Access the computed loss
```

This addition allows for better evaluation of the model's performance during training and fine-tuning tasks.

Additional changes:
- Import `mlx.nn` module in `gpt2.py`
- Update imports in `params.py` and `test_params.py` for better organization
- Modify `test_gpt2.py` to accommodate the new loss calculation feature (full changes not visible in the provided diff)