### PR TITLE
Update LM evaluation script and add Qwen2.5-0.5B model

### DIFF
--- a/eval/lm-eval.sh
+++ b/eval/lm-eval.sh
@@ -36,3 +36,12 @@ poetry run lm_eval --model hf \
 #     --tasks $TASKS \
 #     --device $DEVICE \
 #     --batch_size $BATCH_SIZE
+
+# Qwen/Qwen2.5-0.5B
+# https://huggingface.co/Qwen/Qwen2.5-0.5B
+poetry run lm_eval --model hf \
+    --model_args pretrained=Qwen/Qwen2.5-0.5B \
+    --output_path $OUTPUT_PATH \
+    --tasks $TASKS \
+    --device $DEVICE \
+    --batch_size $BATCH_SIZE

--- a/eval/lm-eval.sh
+++ b/eval/lm-eval.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -x
 
-OUTPUT_PATH="eval/outputs"
-
+OUTPUT_PATH="eval/outputs/$(date '+%Y%m%d_%H%M%S')"
 TASKS="hellaswag,mmlu"
 DEVICE="mps"
 BATCH_SIZE=2

--- a/eval/lm-eval.sh
+++ b/eval/lm-eval.sh
@@ -11,7 +11,6 @@ BATCH_SIZE=2
 poetry run eval --model q \
     --model_args model_size=124M \
     --output_path $OUTPUT_PATH \
-    --log_samples \
     --tasks $TASKS \
     --batch_size $BATCH_SIZE
 
@@ -19,7 +18,6 @@ poetry run eval --model q \
 # poetry run eval --model q \
 #     --model_args model_size=355M \
 #     --output_path $OUTPUT_PATH \
-#     --log_samples \
 #     --tasks $TASKS \
 #     --batch_size $BATCH_SIZE
 
@@ -27,7 +25,6 @@ poetry run eval --model q \
 poetry run lm_eval --model hf \
     --model_args pretrained=gpt2 \
     --output_path $OUTPUT_PATH \
-    --log_samples \
     --tasks $TASKS \
     --device $DEVICE \
     --batch_size $BATCH_SIZE
@@ -36,7 +33,6 @@ poetry run lm_eval --model hf \
 # poetry run lm_eval --model hf \
 #     --model_args pretrained=gpt2-medium \
 #     --output_path $OUTPUT_PATH \
-#     --log_samples \
 #     --tasks $TASKS \
 #     --device $DEVICE \
 #     --batch_size $BATCH_SIZE


### PR DESCRIPTION
This PR updates the `lm-eval.sh` script in the `eval` directory to improve the evaluation process and add support for the Qwen2.5-0.5B model.

Main changes:
1. Modified output path to include timestamp for better organization
2. Removed `--log_samples` flag from all evaluation commands
3. Added evaluation for Qwen2.5-0.5B model

Details:
- The `OUTPUT_PATH` now includes a timestamp: `eval/outputs/$(date '+%Y%m%d_%H%M%S')`
- Removed `--log_samples` flag from all `poetry run eval` and `poetry run lm_eval` commands
- Added a new evaluation command for the Qwen2.5-0.5B model:
  ```bash
  poetry run lm_eval --model hf \
      --model_args pretrained=Qwen/Qwen2.5-0.5B \
      --output_path $OUTPUT_PATH \
      --tasks $TASKS \
      --device $DEVICE \
      --batch_size $BATCH_SIZE
  ```

These changes will help organize evaluation outputs better and allow for testing the Qwen2.5-0.5B model alongside the existing models.