### PR TITLE
Add benchmark script for language model performance metrics

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,4 +14,4 @@ extend-ignore =
     E722
 
 
-max-line-length = 120
+max-line-length = 160

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.out
 
 # Distribution / packaging
 .Python

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Generated 37.19 tokens/sec
 You can run [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness).
 
 ```
-poetry run eval --model q --model_args model_size=355M --tasks hellaswag
+poetry run python -m q.eval --model q --model_args model_size=355M --tasks hellaswag
 ```
 
 and we have [our evaluation script](eval/lm-eval.sh).

--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ poetry run python -m q.eval --model q --model_args model_size=355M --tasks hella
 
 and we have [our evaluation script](eval/lm-eval.sh).
 
+## Benchmark
+
+### TPS (Average)
+
+| `max_length`                                                 | 64    | 128   | 256   |
+| ------------------------------------------------------------ | ----- | ----- | ----- |
+| Q (124M)                                                     | 47.33 | 33.6  | 19.6  |
+| [GPT-2](https://huggingface.co/openai-community/gpt2) (124M) | 53.96 | 51.56 | 54.76 |
+
+### Peak Memory (Average, MB)
+
+| `max_length`                                                 | 64     | 128    | 256     |
+| ------------------------------------------------------------ | ------ | ------ | ------- |
+| Q (124M)                                                     | 780.37 | 581.89 | 537.33  |
+| [GPT-2](https://huggingface.co/openai-community/gpt2) (124M) | 781.96 | 974.82 | 1358.00 |
+
 ## References
 
 - [Language Models are Unsupervised Multitask Learners](https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf)

--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ and we have [our evaluation script](eval/lm-eval.sh).
 | ------------------------------------------------------------ | ----- | ----- | ----- |
 | Q (124M)                                                     | 47.33 | 33.6  | 19.6  |
 | [GPT-2](https://huggingface.co/openai-community/gpt2) (124M) | 53.96 | 51.56 | 54.76 |
+| [Qwen2.5-0.5B](https://huggingface.co/Qwen/Qwen2.5-0.5B)     | 21.80 | 22.33 | 22.24 |
 
 ### Peak Memory (Average, MB)
 
-| `max_length`                                                 | 64     | 128    | 256     |
-| ------------------------------------------------------------ | ------ | ------ | ------- |
-| Q (124M)                                                     | 780.37 | 581.89 | 537.33  |
-| [GPT-2](https://huggingface.co/openai-community/gpt2) (124M) | 781.96 | 974.82 | 1358.00 |
+| `max_length`                                                 | 64      | 128     | 256     |
+| ------------------------------------------------------------ | ------- | ------- | ------- |
+| Q (124M)                                                     | 780.37  | 581.89  | 537.33  |
+| [GPT-2](https://huggingface.co/openai-community/gpt2) (124M) | 781.96  | 974.82  | 1358.00 |
+| [Qwen2.5-0.5B](https://huggingface.co/Qwen/Qwen2.5-0.5B)     | 1257.32 | 1292.65 | 1284.94 |
 
 ## References
 

--- a/eval/bench_transformers.py
+++ b/eval/bench_transformers.py
@@ -115,6 +115,9 @@ class PerformanceMetrics:
 def get_memory_usage() -> float:
     """Get current memory usage in MB."""
     process = psutil.Process(os.getpid())
+    memory_info = process.memory_info()
+
+    print(f"memory_info: {memory_info}")
     return process.memory_info().rss / (1024 * 1024)
 
 
@@ -268,6 +271,7 @@ def run_benchmark(
                     max_length=max_length,
                     device=device,
                 )
+                print("Peak memory usage:", generation_metrics.peak_memory)
 
                 # Track peak memory
                 total_peak_memory += generation_metrics.peak_memory

--- a/eval/bench_transformers.py
+++ b/eval/bench_transformers.py
@@ -19,13 +19,7 @@ import click
 import psutil
 import torch
 from tqdm import tqdm
-from transformers import (
-    AutoModelForCausalLM,
-    AutoTokenizer,
-    MaxLengthCriteria,
-    StoppingCriteriaList,
-    TextIteratorStreamer,
-)
+from transformers import AutoModelForCausalLM, AutoTokenizer, TextIteratorStreamer
 
 # Sample prompts for evaluation
 SAMPLE_PROMPTS = [
@@ -114,7 +108,7 @@ def generate_with_metrics(
     model,
     tokenizer,
     prompt: str,
-    max_length: int = 1024,
+    max_length: int = 100,
     device: str = "mps",
 ) -> Tuple[str, float, float, float, float, int, float]:
     """
@@ -204,9 +198,9 @@ def generate_with_metrics(
 
 def run_benchmark(
     model_name: str,
-    prompts: List[str] = None,
+    prompts: Optional[list[str]] = None,
     output_dir: str = "eval/outputs",
-    max_length: int = 1024,
+    max_length: int = 100,
     device: str = "mps",
     num_runs: int = 1,
     save_generations: bool = True,

--- a/eval/bench_transformers.py
+++ b/eval/bench_transformers.py
@@ -115,7 +115,6 @@ def generate_with_metrics(
     tokenizer,
     prompt: str,
     max_new_tokens: int = 100,
-    temperature: float = 0.7,
     top_p: float = 0.9,
     device: str = "cuda",
 ) -> Tuple[str, float, float, float, float, int, float]:
@@ -153,9 +152,9 @@ def generate_with_metrics(
     generation_kwargs = {
         "input_ids": input_ids,
         "max_new_tokens": max_new_tokens,
-        "temperature": temperature,
+        "temperature": 1.0,  # 固定値 1.0 を使用
         "top_p": top_p,
-        "do_sample": temperature > 0,
+        "do_sample": True,  # temperature は常に 1.0 なので True
         "streamer": streamer,
         "stopping_criteria": stopping_criteria,
     }
@@ -217,7 +216,6 @@ def run_benchmark(
     prompts: List[str] = None,
     output_dir: str = "eval/outputs",
     max_new_tokens: int = 100,
-    temperature: float = 0.7,
     top_p: float = 0.9,
     device: str = "cuda",
     num_runs: int = 1,
@@ -231,7 +229,6 @@ def run_benchmark(
         prompts: List of prompts to test (uses defaults if None)
         output_dir: Directory to save results
         max_new_tokens: Maximum number of tokens to generate
-        temperature: Sampling temperature
         top_p: Top-p sampling parameter
         device: Device to run on ('cuda', 'mps', 'cpu')
         num_runs: Number of times to run each prompt
@@ -282,7 +279,6 @@ def run_benchmark(
                     tokenizer=tokenizer,
                     prompt=prompt,
                     max_new_tokens=max_new_tokens,
-                    temperature=temperature,
                     top_p=top_p,
                     device=device,
                 )
@@ -350,7 +346,7 @@ def run_benchmark(
         "device": device,
         "parameters": {
             "max_new_tokens": max_new_tokens,
-            "temperature": temperature,
+            "temperature": 1.0,  # 常に 1.0 を使用
             "top_p": top_p,
             "num_runs": num_runs,
             "num_prompts": len(prompts),
@@ -402,7 +398,6 @@ def run_benchmark(
 @click.option(
     "--max-new-tokens", default=100, type=int, help="Maximum tokens to generate"
 )
-@click.option("--temperature", default=0.7, type=float, help="Sampling temperature")
 @click.option("--top-p", default=0.9, type=float, help="Top-p sampling parameter")
 @click.option(
     "--device", default="mps", type=str, help="Device to run on (cuda, mps, cpu)"
@@ -414,7 +409,6 @@ def main(
     pretrained: str,
     output_path: str,
     max_new_tokens: int,
-    temperature: float,
     top_p: float,
     device: str,
     num_runs: int,
@@ -449,7 +443,6 @@ def main(
         prompts=custom_prompts,
         output_dir=output_path,
         max_new_tokens=max_new_tokens,
-        temperature=temperature,
         top_p=top_p,
         device=device,
         num_runs=num_runs,

--- a/eval/bench_transformers.py
+++ b/eval/bench_transformers.py
@@ -116,8 +116,10 @@ def get_memory_usage() -> float:
     """Get current memory usage in MB."""
     process = psutil.Process(os.getpid())
     memory_info = process.memory_info()
+    memory_full_info = process.memory_full_info()
 
     print(f"memory_info: {memory_info}")
+    print(f"memory_full_info: {memory_full_info}")
     return process.memory_info().rss / (1024 * 1024)
 
 

--- a/eval/bench_transformers.py
+++ b/eval/bench_transformers.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python
+"""
+Benchmark script for measuring language model performance metrics:
+- TTFT (Time to First Token)
+- TPS (Tokens Per Second)
+- Memory Usage
+"""
+
+import gc
+import json
+import os
+import statistics
+import time
+from datetime import datetime
+from threading import Thread
+from typing import Any, Dict, List, Optional, Tuple
+
+import click
+import psutil
+import torch
+from tqdm import tqdm
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    MaxLengthCriteria,
+    StoppingCriteriaList,
+    TextIteratorStreamer,
+)
+
+# Sample prompts for evaluation
+SAMPLE_PROMPTS = [
+    "Explain the concept of machine learning to a 5-year-old.",
+    "Write a short poem about artificial intelligence.",
+    "What are the key differences between Python and JavaScript?",
+    "Describe the process of photosynthesis in plants.",
+    "Explain how transformers work in natural language processing.",
+    "Write a function in Python to find the nth Fibonacci number.",
+    "What are the ethical concerns associated with AI development?",
+    "Explain the theory of relativity in simple terms.",
+    "Write a short story about a robot discovering emotions.",
+    "How does quantum computing differ from classical computing?",
+]
+
+
+class PerformanceMetrics:
+    """Class to track and calculate model performance metrics."""
+
+    def __init__(self):
+        self.ttft_samples: List[float] = []
+        self.tps_samples: List[float] = []
+        self.memory_samples: List[float] = []
+        self.token_counts: List[int] = []
+        self.generation_times: List[float] = []
+
+    def add_sample(
+        self,
+        ttft: float,
+        tps: float,
+        memory_usage: float,
+        token_count: int,
+        generation_time: float,
+    ):
+        """Add a performance sample to the metrics."""
+        self.ttft_samples.append(ttft)
+        self.tps_samples.append(tps)
+        self.memory_samples.append(memory_usage)
+        self.token_counts.append(token_count)
+        self.generation_times.append(generation_time)
+
+    def calculate_statistics(self) -> Dict[str, Any]:
+        """Calculate statistics for all metrics."""
+        return {
+            "ttft": {
+                "mean": statistics.mean(self.ttft_samples),
+                "median": statistics.median(self.ttft_samples),
+                "min": min(self.ttft_samples),
+                "max": max(self.ttft_samples),
+                "samples": self.ttft_samples,
+            },
+            "tps": {
+                "mean": statistics.mean(self.tps_samples),
+                "median": statistics.median(self.tps_samples),
+                "min": min(self.tps_samples),
+                "max": max(self.tps_samples),
+                "samples": self.tps_samples,
+            },
+            "memory_usage_mb": {
+                "mean": statistics.mean(self.memory_samples),
+                "median": statistics.median(self.memory_samples),
+                "min": min(self.memory_samples),
+                "max": max(self.memory_samples),
+                "samples": self.memory_samples,
+            },
+            "token_counts": {
+                "mean": statistics.mean(self.token_counts),
+                "total": sum(self.token_counts),
+                "samples": self.token_counts,
+            },
+            "generation_times": {
+                "mean": statistics.mean(self.generation_times),
+                "total": sum(self.generation_times),
+                "samples": self.generation_times,
+            },
+        }
+
+
+def get_memory_usage() -> float:
+    """Get current memory usage in MB."""
+    process = psutil.Process(os.getpid())
+    return process.memory_info().rss / (1024 * 1024)
+
+
+def generate_with_metrics(
+    model,
+    tokenizer,
+    prompt: str,
+    max_new_tokens: int = 100,
+    temperature: float = 0.7,
+    top_p: float = 0.9,
+    device: str = "cuda",
+) -> Tuple[str, float, float, float, int, float]:
+    """
+    Generate text from a prompt and measure performance metrics.
+
+    Returns:
+        Tuple containing (generated_text, ttft, tps, memory_usage, token_count, total_time)
+    """
+    # Clear CUDA cache if device is CUDA
+    if device == "cuda" and torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # Garbage collect to start with a clean slate
+    gc.collect()
+
+    # Record initial memory
+    initial_memory = get_memory_usage()
+
+    # Tokenize the prompt
+    input_ids = tokenizer.encode(prompt, return_tensors="pt").to(device)
+
+    # Set up streamer for monitoring token generation
+    streamer = TextIteratorStreamer(
+        tokenizer, skip_prompt=True, skip_special_tokens=True
+    )
+
+    # Set up stopping criteria
+    stopping_criteria = StoppingCriteriaList(
+        [MaxLengthCriteria(max_length=input_ids.shape[1] + max_new_tokens)]
+    )
+
+    # Prepare generation parameters
+    generation_kwargs = {
+        "input_ids": input_ids,
+        "max_new_tokens": max_new_tokens,
+        "temperature": temperature,
+        "top_p": top_p,
+        "do_sample": temperature > 0,
+        "streamer": streamer,
+        "stopping_criteria": stopping_criteria,
+    }
+
+    # Start generation in a separate thread
+    start_time = time.time()
+    thread = Thread(target=model.generate, kwargs=generation_kwargs)
+    thread.start()
+
+    # Monitor token generation
+    first_token_time = None
+    generated_text = ""
+    token_count = 0
+
+    for new_text in streamer:
+        if first_token_time is None:
+            first_token_time = time.time()
+
+        generated_text += new_text
+        token_count += 1
+
+    # Wait for the thread to complete
+    thread.join()
+    end_time = time.time()
+
+    # Calculate metrics
+    ttft = first_token_time - start_time if first_token_time else 0
+    total_time = end_time - start_time
+    tps = (
+        token_count / (total_time - ttft)
+        if token_count > 0 and (total_time - ttft) > 0
+        else 0
+    )
+    peak_memory = get_memory_usage() - initial_memory
+
+    return generated_text, ttft, tps, peak_memory, token_count, total_time
+
+
+def run_benchmark(
+    model_name: str,
+    prompts: List[str] = None,
+    output_dir: str = "eval/outputs",
+    max_new_tokens: int = 100,
+    temperature: float = 0.7,
+    top_p: float = 0.9,
+    device: str = "cuda",
+    num_runs: int = 1,
+    save_generations: bool = True,
+) -> Dict[str, Any]:
+    """
+    Run performance benchmark on a model.
+
+    Args:
+        model_name: HuggingFace model identifier
+        prompts: List of prompts to test (uses defaults if None)
+        output_dir: Directory to save results
+        max_new_tokens: Maximum number of tokens to generate
+        temperature: Sampling temperature
+        top_p: Top-p sampling parameter
+        device: Device to run on ('cuda', 'mps', 'cpu')
+        num_runs: Number of times to run each prompt
+        save_generations: Whether to save generated text
+
+    Returns:
+        Dictionary with benchmark results
+    """
+    if prompts is None:
+        prompts = SAMPLE_PROMPTS
+
+    # Load model and tokenizer
+    print(f"Loading model: {model_name}")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        torch_dtype=torch.float16 if device in ["cuda", "mps"] else torch.float32,
+        device_map=device,
+    )
+
+    # Ensure output directory exists
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Setup metrics tracker
+    metrics = PerformanceMetrics()
+
+    # Storage for generated outputs
+    generations = []
+
+    # Run benchmark
+    for prompt_idx, prompt in enumerate(prompts):
+        prompt_metrics = PerformanceMetrics()
+
+        for run in tqdm(range(num_runs), desc=f"Prompt {prompt_idx+1}/{len(prompts)}"):
+            try:
+                generated_text, ttft, tps, memory_usage, token_count, total_time = (
+                    generate_with_metrics(
+                        model=model,
+                        tokenizer=tokenizer,
+                        prompt=prompt,
+                        max_new_tokens=max_new_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        device=device,
+                    )
+                )
+
+                # Add to metrics
+                metrics.add_sample(ttft, tps, memory_usage, token_count, total_time)
+                prompt_metrics.add_sample(
+                    ttft, tps, memory_usage, token_count, total_time
+                )
+
+                if save_generations:
+                    generations.append(
+                        {
+                            "prompt": prompt,
+                            "generated_text": generated_text,
+                            "prompt_idx": prompt_idx,
+                            "run": run,
+                            "metrics": {
+                                "ttft": ttft,
+                                "tps": tps,
+                                "memory_usage_mb": memory_usage,
+                                "token_count": token_count,
+                                "total_time": total_time,
+                            },
+                        }
+                    )
+
+                # Give GPU some time to cool down between runs if using CUDA
+                if device == "cuda":
+                    time.sleep(0.5)
+
+            except Exception as e:
+                print(f"Error during generation: {e}")
+                continue
+
+        # Print prompt summary
+        prompt_stats = prompt_metrics.calculate_statistics()
+        print(f"\nPrompt {prompt_idx+1} Summary:")
+        print(
+            f"  TTFT: {prompt_stats['ttft']['mean']:.4f}s (median: {prompt_stats['ttft']['median']:.4f}s)"
+        )
+        print(
+            f"  TPS: {prompt_stats['tps']['mean']:.2f} tokens/sec (median: {prompt_stats['tps']['median']:.2f})"
+        )
+        print(
+            f"  Memory: {prompt_stats['memory_usage_mb']['mean']:.2f}MB (peak: {prompt_stats['memory_usage_mb']['max']:.2f}MB)"
+        )
+
+    # Calculate statistics
+    final_stats = metrics.calculate_statistics()
+
+    # Create benchmark results
+    results = {
+        "model": model_name,
+        "device": device,
+        "parameters": {
+            "max_new_tokens": max_new_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "num_runs": num_runs,
+            "num_prompts": len(prompts),
+        },
+        "metrics": final_stats,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    # Save results
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    model_shortname = model_name.split("/")[-1]
+
+    # Save summary results
+    results_path = os.path.join(output_dir, f"bench_{model_shortname}_{timestamp}.json")
+    with open(results_path, "w") as f:
+        json.dump(results, f, indent=2)
+
+    # Save generations if requested
+    if save_generations and generations:
+        generations_path = os.path.join(
+            output_dir, f"bench_{model_shortname}_generations_{timestamp}.json"
+        )
+        with open(generations_path, "w") as f:
+            json.dump(generations, f, indent=2)
+
+    print(f"\nBenchmark complete! Results saved to {results_path}")
+
+    # Print summary
+    print("\nSummary:")
+    print(f"  Average TTFT: {final_stats['ttft']['mean']:.4f}s")
+    print(f"  Average TPS: {final_stats['tps']['mean']:.2f} tokens/sec")
+    print(f"  Average Memory Usage: {final_stats['memory_usage_mb']['mean']:.2f}MB")
+    print(f"  Peak Memory Usage: {final_stats['memory_usage_mb']['max']:.2f}MB")
+    print(f"  Total Tokens Generated: {final_stats['token_counts']['total']}")
+    print(f"  Total Generation Time: {final_stats['generation_times']['total']:.2f}s")
+
+    return results
+
+
+@click.command()
+@click.option("--pretrained", required=True, help="HuggingFace model name or path")
+@click.option("--output-path", default="eval/outputs", help="Directory to save results")
+@click.option(
+    "--max-new-tokens", default=100, type=int, help="Maximum tokens to generate"
+)
+@click.option("--temperature", default=0.7, type=float, help="Sampling temperature")
+@click.option("--top-p", default=0.9, type=float, help="Top-p sampling parameter")
+@click.option(
+    "--device", default="mps", type=str, help="Device to run on (cuda, mps, cpu)"
+)
+@click.option("--num-runs", default=3, type=int, help="Number of runs per prompt")
+@click.option("--prompts-file", type=str, help="JSON file with custom prompts")
+@click.option("--no-save-generations", is_flag=True, help="Don't save generated text")
+def main(
+    pretrained: str,
+    output_path: str,
+    max_new_tokens: int,
+    temperature: float,
+    top_p: float,
+    device: str,
+    num_runs: int,
+    prompts_file: Optional[str],
+    no_save_generations: bool,
+):
+    """Benchmark a transformer model's performance metrics."""
+    # Set device
+    if device == "cuda" and not torch.cuda.is_available():
+        print("CUDA not available, falling back to CPU")
+        device = "cpu"
+    elif device == "mps" and not torch.backends.mps.is_available():
+        print("MPS not available, falling back to CPU")
+        device = "cpu"
+
+    print(f"Running on device: {device}")
+
+    # Load custom prompts if provided
+    custom_prompts = None
+    if prompts_file:
+        try:
+            with open(prompts_file, "r") as f:
+                custom_prompts = json.load(f)
+            print(f"Loaded {len(custom_prompts)} custom prompts from {prompts_file}")
+        except Exception as e:
+            print(f"Error loading prompts file: {e}")
+            return
+
+    # Run benchmark
+    run_benchmark(
+        model_name=pretrained,
+        prompts=custom_prompts,
+        output_dir=output_path,
+        max_new_tokens=max_new_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        device=device,
+        num_runs=num_runs,
+        save_generations=not no_save_generations,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/lm-bench.sh
+++ b/eval/lm-bench.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -x
 
-poetry run python -m q.bench.cli
-poetry run python -m q.bench.cli --pretrained gpt2
+OUTPUT_PATH="eval/outputs/$(date '+%Y%m%d_%H%M%S')"
+
+for max_length in 64 128 256
+do
+    echo "Running with max length $max_length"
+    poetry run python -m q.bench.cli --output-path="$OUTPUT_PATH" --max-length="$max_length"
+    poetry run python -m q.bench.cli --output-path="$OUTPUT_PATH" --model gpt2 --max-length="$max_length"
+done

--- a/eval/lm-bench.sh
+++ b/eval/lm-bench.sh
@@ -8,4 +8,5 @@ do
     echo "Running with max length $max_length"
     poetry run python -m q.bench.cli --output-path="$OUTPUT_PATH" --max-length="$max_length"
     poetry run python -m q.bench.cli --output-path="$OUTPUT_PATH" --model gpt2 --max-length="$max_length"
+    poetry run python -m q.bench.cli --output-path="$OUTPUT_PATH" --model Qwen/Qwen2.5-0.5B --max-length="$max_length"
 done

--- a/eval/lm-bench.sh
+++ b/eval/lm-bench.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -x
+
+poetry run python -m q.bench.cli
+poetry run python -m q.bench.cli --pretrained gpt2

--- a/eval/lm-eval.sh
+++ b/eval/lm-eval.sh
@@ -7,14 +7,14 @@ DEVICE="mps"
 BATCH_SIZE=2
 
 # q (124M)
-poetry run eval --model q \
+poetry run python -m q.eval --model q \
     --model_args model_size=124M \
     --output_path $OUTPUT_PATH \
     --tasks $TASKS \
     --batch_size $BATCH_SIZE
 
 # q (355M)
-# poetry run eval --model q \
+# poetry run python -m q.eval --model q \
 #     --model_args model_size=355M \
 #     --output_path $OUTPUT_PATH \
 #     --tasks $TASKS \

--- a/q/bench/base.py
+++ b/q/bench/base.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BenchTextGenerationOutput:
+    generated_text: str
+    token_count: int
+    peak_memory: float
+
+
+class BenchTextGeneration:
+    def generate(self, prompt: str, max_length: int) -> BenchTextGenerationOutput:
+        raise NotImplementedError()

--- a/q/bench/hf.py
+++ b/q/bench/hf.py
@@ -1,0 +1,64 @@
+import os
+
+import psutil
+import torch
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    PreTrainedTokenizer,
+    PreTrainedTokenizerFast,
+)
+from transformers.generation.streamers import BaseStreamer
+
+from .base import BenchTextGeneration, BenchTextGenerationOutput
+
+
+class HFBenchTextGeneration(BenchTextGeneration):
+    """Class to represent a Hugging Face transformer model."""
+
+    model_name: str
+    model: AutoModelForCausalLM
+    tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast
+
+    def __init__(self, model_name: str):
+        self.model_name = model_name
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            torch_dtype=torch.float16,
+            device_map="mps",
+        )
+
+    def generate(self, prompt: str, max_length: int) -> BenchTextGenerationOutput:
+        streamer = MemoryProfileStreamer()
+
+        input_ids = self.tokenizer.encode(prompt, return_tensors="pt").to("mps")  # type: ignore
+        generated_tokens = self.model.generate(  # type: ignore
+            input_ids=input_ids,
+            max_length=max_length,
+            temperature=1.0,
+            streamer=streamer,
+        )
+
+        generated_text = self.tokenizer.decode(
+            generated_tokens[0], skip_special_tokens=True
+        )
+
+        token_count = generated_tokens.shape[1] - input_ids.shape[1]
+        return BenchTextGenerationOutput(
+            generated_text=generated_text,
+            token_count=token_count,
+            peak_memory=streamer.peak_memory,
+        )
+
+
+class MemoryProfileStreamer(BaseStreamer):
+    peak_memory: float = 0.0
+
+    def put(self, value):
+        process = psutil.Process(os.getpid())
+        rss = process.memory_info().rss / (1024 * 1024)
+        self.peak_memory = max(self.peak_memory, rss)
+
+    def end(self):
+        pass

--- a/q/bench/q.py
+++ b/q/bench/q.py
@@ -1,0 +1,51 @@
+import os
+
+import psutil
+
+from q.common import ModelSize
+from q.encoder import load_encoder
+from q.generation import TokenGenerator
+from q.gpt2 import GPT2Model
+from q.params import load_hparams_and_params
+
+from .base import BenchTextGeneration, BenchTextGenerationOutput
+
+DEFAULT_MODELS_DIR = os.path.join(os.path.dirname(__file__), "..", "models")
+
+
+class QBenchTextGeneration(BenchTextGeneration):
+
+    def __init__(
+        self,
+        model_size: ModelSize = "124M",
+        models_dir: str = "models",
+    ):
+        self.encoder = load_encoder(model_size, models_dir)
+        hparams, params = load_hparams_and_params(
+            model_size=model_size,
+            models_dir=models_dir,
+        )
+
+        self.model = GPT2Model(params, hparams)
+        self.generator = TokenGenerator(self.model)
+
+    def generate(self, prompt: str, max_length: int) -> BenchTextGenerationOutput:
+        peak_memory = 0.0
+        output_ids = []
+
+        input_ids = self.encoder.encode(prompt)
+
+        for token in self.generator(input_ids, max_length=max_length):
+            process = psutil.Process(os.getpid())
+            rss = process.memory_info().rss / (1024 * 1024)
+            peak_memory = max(peak_memory, rss)
+            output_ids.append(token)
+
+        generated_text = self.encoder.decode(output_ids)
+
+        token_count = len(output_ids)
+        return BenchTextGenerationOutput(
+            generated_text=generated_text,
+            token_count=token_count,
+            peak_memory=peak_memory,
+        )

--- a/q/eval.py
+++ b/q/eval.py
@@ -299,7 +299,7 @@ class QLM(TemplateLM):
             batch_indices, batch_windows = zip(*batch)
 
             batch_nlls = self._loglikelihood_tokens(
-                requests=batch_windows,
+                requests=batch_windows,  # type: ignore
                 disable_tqdm=False,
                 override_bs=len(batch_windows),
             )
@@ -416,3 +416,7 @@ def main():
     print(f"Setting mlx seed to {mlx_random_seed}")
 
     cli_evaluate()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mac_mem_usage.c
+++ b/scripts/mac_mem_usage.c
@@ -17,7 +17,7 @@ int main()
     }
 
     // 確保したメモリに適当な値を書き込む
-    memset(memory, 42, FIFTY_MB); // 42という値で埋める
+    memset(memory, 43, FIFTY_MB); // 42という値で埋める
     printf("Allocated 50MB of memory and filled with data\n");
 
     while (1) // 無限ループに変更
@@ -30,9 +30,13 @@ int main()
                                      &count);
         if (kr == KERN_SUCCESS)
         {
-            printf("phys_footprint: %llu bytes\n", info.phys_footprint);
-            printf("resident_size:  %llu bytes\n", info.resident_size);
-            printf("virtual_size:   %llu bytes\n", info.virtual_size);
+            printf("phys_footprint: %.2fMB %llu bytes\n", (info.phys_footprint / 1024.0 / 1024.0), info.phys_footprint);
+            printf("resident_size:  %.2fMB %llu bytes\n", (info.resident_size / 1024.0 / 1024.0), info.resident_size);
+            printf("virtual_size:   %.2fMB %llu bytes\n", (info.virtual_size / 1024.0 / 1024.0), info.virtual_size);
+            printf("internal:   %.2fMB %llu bytes\n", (info.internal / 1024.0 / 1024.0), info.internal);
+            printf("external:   %.2fMB %.2fKB %llu bytes\n", (info.external / 1024.0 / 1024.0), (info.external / 1024.0), info.external);
+            printf("reusable:   %.2fMB %llu bytes\n", (info.reusable / 1024.0 / 1024.0), info.reusable);
+            printf("compressed: %.2fMB %llu bytes\n", (info.compressed / 1024.0 / 1024.0), info.compressed);
             printf("------------------------------\n"); // 区切り線を追加
         }
 

--- a/scripts/mac_mem_usage.c
+++ b/scripts/mac_mem_usage.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <mach/mach.h>
+#include <unistd.h> // sleep 関数のために追加
+#include <stdlib.h> // malloc, free のために追加
+#include <string.h> // memset のために追加
+
+#define FIFTY_MB (50 * 1024 * 1024) // 50MB
+
+int main()
+{
+    // 50MB のメモリを確保
+    char *memory = (char *)malloc(FIFTY_MB);
+    if (memory == NULL)
+    {
+        printf("Failed to allocate memory\n");
+        return 1;
+    }
+
+    // 確保したメモリに適当な値を書き込む
+    memset(memory, 42, FIFTY_MB); // 42という値で埋める
+    printf("Allocated 50MB of memory and filled with data\n");
+
+    while (1) // 無限ループに変更
+    {
+        struct task_vm_info info;
+        mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+        kern_return_t kr = task_info(mach_task_self(),
+                                     TASK_VM_INFO,
+                                     (task_info_t)&info,
+                                     &count);
+        if (kr == KERN_SUCCESS)
+        {
+            printf("phys_footprint: %llu bytes\n", info.phys_footprint);
+            printf("resident_size:  %llu bytes\n", info.resident_size);
+            printf("virtual_size:   %llu bytes\n", info.virtual_size);
+            printf("------------------------------\n"); // 区切り線を追加
+        }
+
+        sleep(1); // 1秒間スリープ
+    }
+
+    // この行は実行されないが、念のため
+    free(memory);
+    return 0;
+}


### PR DESCRIPTION
This PR introduces a new benchmark script for measuring language model performance metrics, including Time to First Token (TTFT), Tokens Per Second (TPS), and Memory Usage.

Main changes:
1. Added a new file `eval/bench_transformers.py` containing the benchmark script.
2. Modified `.flake8` to increase the maximum line length from 120 to 160 characters.

The benchmark script includes the following features:
- A `PerformanceMetrics` class to track and calculate various performance metrics.
- Sample prompts for evaluation.
- Utilizes the `transformers` library to load and run language models.
- Measures TTFT, TPS, and memory usage for model inference.

This script will help in evaluating and comparing the performance of different language models, which is crucial for optimizing model selection and deployment.

Implementation details:
- The script uses `AutoModelForCausalLM` and `AutoTokenizer` from the `transformers` library.
- It leverages `TextIteratorStreamer` for token streaming during generation.
- Performance metrics are calculated using the `statistics` module.

The increase in maximum line length in `.flake8` is to accommodate longer lines in the new benchmark script without triggering linting errors.